### PR TITLE
chore: format file and optimise resources

### DIFF
--- a/.k8s/testnet/omstead-7888/kustomization.yaml
+++ b/.k8s/testnet/omstead-7888/kustomization.yaml
@@ -23,33 +23,45 @@ labels:
     includeTemplates: true
 
 helmCharts:
-#
-# BLOCKSCOUT STACK
-#
-- name: blockscout-stack
-  repo: https://blockscout.github.io/helm-charts
-  version: 3.0.0
-  releaseName: blockscout-stack
-  valuesInline:
-    config:
-      network:
-        id: 7888
-        name: om
-        shortname: om
-        currency:
+  #
+  # BLOCKSCOUT STACK
+  #
+  - name: blockscout-stack
+    repo: https://blockscout.github.io/helm-charts
+    version: 3.0.0
+    releaseName: blockscout-stack
+    valuesInline:
+      config:
+        network:
+          id: 7888
           name: om
-          symbol: OM
-          decimals: 6
-      prometheus:
-        enabled: false
-    blockscout:
-      replicaCount: 2
-      envFrom:
-        - configMapRef:
-            name: backend-env-variables
-    frontend:
-       envFrom:
-        - configMapRef:
-            name: frontend-env-variables 
-    nodeSelector:
-      cloud.google.com/gke-spot: "true"
+          shortname: om
+          currency:
+            name: om
+            symbol: OM
+            decimals: 6
+        prometheus:
+          enabled: false
+      blockscout:
+        replicaCount: 2
+        envFrom:
+          - configMapRef:
+              name: backend-env-variables
+        resources:
+          requests:
+            cpu: 400m
+            memory: 500Mi
+          limits:
+            cpu: 1
+            memory: 1Gi
+      frontend:
+        envFrom:
+          - configMapRef:
+              name: frontend-env-variables
+        resources:
+          requests:
+            cpu: 50m
+            memory: 300Mi
+          limits:
+            cpu: 200m
+            memory: 1Gi


### PR DESCRIPTION
This pull request introduces resource requests and limits for the `backend` and `frontend` services in the Kubernetes configuration file while removing the `nodeSelector` configuration for spot instances.

Resource configuration updates:

* `backend` service: Added resource requests of `400m` CPU and `500Mi` memory, and limits of `1` CPU and `1Gi` memory in `.k8s/testnet/omstead-7888/kustomization.yaml`.
* `frontend` service: Added resource requests of `50m` CPU and `300Mi` memory, and limits of `200m` CPU and `1Gi` memory in `.k8s/testnet/omstead-7888/kustomization.yaml`.

Configuration simplification:

* Removed `nodeSelector` for spot instances (`cloud.google.com/gke-spot: "true"`) from `.k8s/testnet/omstead-7888/kustomization.yaml`.